### PR TITLE
Fix a bug in mut-vars: functions should be first-class

### DIFF
--- a/mut-vars/L2/semantics.rkt
+++ b/mut-vars/L2/semantics.rkt
@@ -26,14 +26,15 @@
            (syntax-case stx (set-to do-not-unbox)
              [v                (identifier? #'v) #'(unbox corresponding-tmp-var-name)]
              [(v set-to w)     (identifier? #'v) #'(set-box! corresponding-tmp-var-name w)]
-             [(v do-not-unbox) (identifier? #'v) #'corresponding-tmp-var-name])))]))
+             [(v do-not-unbox) (identifier? #'v) #'corresponding-tmp-var-name]
+             [(v . rest) (identifier? #'v) #'(app-by-ref (unbox corresponding-tmp-var-name) . rest)])))]))
      
 
 (define-syntax (deffun stx)
   (syntax-parse stx
     [(_ (fname:id arg:id ...) body:expr ...+)
      (with-syntax ([(tmp ...) (generate-temporaries #'(arg ...))])
-       #'(define fname
+       #'(defvar fname
            (record-local-function
             (lambda (arg ...)
               (let ([tmp arg] ...)


### PR DESCRIPTION
See this post for details:

https://edstem.org/us/courses/13507/discussion/696012