### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ instance,
 
     [fun-calls +]
     begin
-    vset
+    set!
 
 `begin` allows a sequence of expressions:
 


### PR DESCRIPTION
The `vset` in `mut-vars` should be `set!`. Thanks Suzzanne Rivoire and her student for catching this!